### PR TITLE
Feature/workflow inputs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,8 +3,6 @@ FROM mcr.microsoft.com/devcontainers/base:noble
 # VS Code commit ID for devcontainer compatibility, argument supplied at build time via devcontainer.json
 ARG VSCODE_COMMIT
 
-ENV VSCODE_COMMIT=${VSCODE_COMMIT}
-
 # Copy and run VS Code installation files
 COPY ./vscode-init /opt/vscode-init
 RUN cd /opt/vscode-init \ 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,6 +3,8 @@ FROM mcr.microsoft.com/devcontainers/base:noble
 # VS Code commit ID for devcontainer compatibility, argument supplied at build time via devcontainer.json
 ARG VSCODE_COMMIT
 
+ENV VSCODE_COMMIT=${VSCODE_COMMIT}
+
 # Copy and run VS Code installation files
 COPY ./vscode-init /opt/vscode-init
 RUN cd /opt/vscode-init \ 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			"VSCODE_COMMIT": "f220831ea2d946c0dcb0f3eaa480eb435a2c1260"
+			"VSCODE_COMMIT": "${VSCODE_COMMIT:-f220831ea2d946c0dcb0f3eaa480eb435a2c1260}"
 		}
 	},
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,6 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
 {
 	"name": "Python Development Environment",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			"VSCODE_COMMIT": "${localEnv:VSCODE_COMMIT:0f0d87fa9e96c856c5212fc86db137ac0d783365}"
+			"VSCODE_COMMIT": "${localEnv:VSCODE_COMMIT:f220831ea2d946c0dcb0f3eaa480eb435a2c1260}"
 		}
 	},
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			"VSCODE_COMMIT": "${VSCODE_COMMIT:-f220831ea2d946c0dcb0f3eaa480eb435a2c1260}"
+			"VSCODE_COMMIT": "${localEnv:VSCODE_COMMIT:0f0d87fa9e96c856c5212fc86db137ac0d783365}"
 		}
 	},
 

--- a/.github/workflows/build-devcontainer.yml
+++ b/.github/workflows/build-devcontainer.yml
@@ -39,7 +39,7 @@ jobs:
         id: vscode-commit
         run: |
           # For manual dispatch, use the input; for PRs use default value for tagging
-          VSCODE_COMMIT="${{ github.event.inputs.vscode_commit }}"
+          VSCODE_COMMIT="${{ env.VSCODE_COMMIT }}"
           VSCODE_SHORT=${VSCODE_COMMIT:0:7}
           echo "vscode_commit=$VSCODE_COMMIT" >> $GITHUB_OUTPUT
           echo "vscode_short=$VSCODE_SHORT" >> $GITHUB_OUTPUT
@@ -78,14 +78,13 @@ jobs:
 
       - name: Build and publish dev container
         uses: devcontainers/ci@v0.3
-        env:
-          # Only override VSCODE_COMMIT for manual dispatch; PRs use devcontainer.json default
-          VSCODE_COMMIT: ${{ steps.vscode-commit.outputs.vscode_commit }}
         with:
           imageName: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           imageTag: ${{ steps.tags.outputs.tags }}
           cacheFrom: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           push: always
+          env: |
+            VSCODE_COMMIT=${{ steps.vscode-commit.outputs.vscode_commit }}
           # Test the container with a simple validation
           runCmd: |
             echo "=== Testing dev container ==="

--- a/.github/workflows/build-devcontainer.yml
+++ b/.github/workflows/build-devcontainer.yml
@@ -18,7 +18,7 @@ env:
   # Set a default VS Code commit hash for tagging purposes
   # This can be overridden via workflow_dispatch input if needed
   # For PRs, the default value will be used
-  VSCODE_COMMIT: ${{ github.event.inputs.vscode_commit || 'f220831ea2d946c0dcb0f3eaa480eb435a2c1260' }}
+  VSCODE_COMMIT: ${{ github.event.inputs.vscode_commit }}
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 

--- a/.github/workflows/build-devcontainer.yml
+++ b/.github/workflows/build-devcontainer.yml
@@ -1,12 +1,6 @@
 name: Build and Publish Dev Container
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - '.devcontainer/**'
-      - '.github/workflows/build-devcontainer.yml'
   pull_request:
     branches:
       - main
@@ -14,6 +8,11 @@ on:
       - '.devcontainer/**'
       - '.github/workflows/build-devcontainer.yml'
   workflow_dispatch:
+    inputs:
+      vscode_commit:
+        description: 'VS Code commit hash to use'
+        required: true
+        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -32,10 +31,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Read VSCODE_COMMIT from devcontainer.json
+      - name: Determine VSCODE_COMMIT
         id: vscode-commit
         run: |
-          VSCODE_COMMIT=$(grep 'VSCODE_COMMIT' .devcontainer/devcontainer.json | tr -d '"' | cut -d " " -f 2)
+          # For manual dispatch, use the required input
+          # For PR builds, read from devcontainer.json
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VSCODE_COMMIT="${{ github.event.inputs.vscode_commit }}"
+            echo "Using VSCODE_COMMIT from workflow input: $VSCODE_COMMIT"
+          else
+            VSCODE_COMMIT=$(grep 'VSCODE_COMMIT' .devcontainer/devcontainer.json | tr -d '"' | cut -d " " -f 2)
+            echo "Using VSCODE_COMMIT from devcontainer.json: $VSCODE_COMMIT"
+          fi
+          
           VSCODE_SHORT=${VSCODE_COMMIT:0:7}
           echo "vscode_commit=$VSCODE_COMMIT" >> $GITHUB_OUTPUT
           echo "vscode_short=$VSCODE_SHORT" >> $GITHUB_OUTPUT
@@ -76,6 +84,9 @@ jobs:
 
       - name: Build and publish dev container
         uses: devcontainers/ci@v0.3
+        env:
+          # Pass the resolved VSCODE_COMMIT as an environment variable for the build
+          VSCODE_COMMIT: ${{ steps.vscode-commit.outputs.vscode_commit }}
         with:
           imageName: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           imageTag: ${{ steps.tags.outputs.tags }}

--- a/.github/workflows/build-devcontainer.yml
+++ b/.github/workflows/build-devcontainer.yml
@@ -11,7 +11,7 @@ on:
     inputs:
       vscode_commit:
         description: 'VS Code commit hash to use'
-        required: false
+        required: true
         type: string
 
 env:

--- a/.github/workflows/build-devcontainer.yml
+++ b/.github/workflows/build-devcontainer.yml
@@ -11,10 +11,14 @@ on:
     inputs:
       vscode_commit:
         description: 'VS Code commit hash to use'
-        required: true
+        required: false
         type: string
 
 env:
+  # Set a default VS Code commit hash for tagging purposes
+  # This can be overridden via workflow_dispatch input if needed
+  # For PRs, the default value will be used
+  VSCODE_COMMIT: ${{ github.event.inputs.vscode_commit || 'f220831ea2d946c0dcb0f3eaa480eb435a2c1260' }}
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
@@ -31,23 +35,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Override VSCODE_COMMIT if provided
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          # Update devcontainer.json with the provided VSCODE_COMMIT
-          sed -i 's/"VSCODE_COMMIT": "${VSCODE_COMMIT:-[^}]*}"/"VSCODE_COMMIT": "${{ github.event.inputs.vscode_commit }}"/' .devcontainer/devcontainer.json
-          echo "Updated devcontainer.json with VSCODE_COMMIT: ${{ github.event.inputs.vscode_commit }}"
-
-      - name: Read VSCODE_COMMIT from devcontainer.json
+      - name: Set VSCODE_COMMIT for tagging
         id: vscode-commit
         run: |
-          # Always read from devcontainer.json (which may have been updated above)
-          VSCODE_COMMIT=$(grep 'VSCODE_COMMIT' .devcontainer/devcontainer.json | tr -d '"' | cut -d " " -f 2)
+          # For manual dispatch, use the input; for PRs use default value for tagging
+          VSCODE_COMMIT="${{ github.event.inputs.vscode_commit }}"
           VSCODE_SHORT=${VSCODE_COMMIT:0:7}
           echo "vscode_commit=$VSCODE_COMMIT" >> $GITHUB_OUTPUT
           echo "vscode_short=$VSCODE_SHORT" >> $GITHUB_OUTPUT
-          echo "Using VSCODE_COMMIT: $VSCODE_COMMIT"
-          echo "Short VSCODE_COMMIT: $VSCODE_SHORT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -84,7 +79,7 @@ jobs:
       - name: Build and publish dev container
         uses: devcontainers/ci@v0.3
         env:
-          # Pass the resolved VSCODE_COMMIT as an environment variable for the build
+          # Only override VSCODE_COMMIT for manual dispatch; PRs use devcontainer.json default
           VSCODE_COMMIT: ${{ steps.vscode-commit.outputs.vscode_commit }}
         with:
           imageName: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/build-devcontainer.yml
+++ b/.github/workflows/build-devcontainer.yml
@@ -78,13 +78,13 @@ jobs:
 
       - name: Build and publish dev container
         uses: devcontainers/ci@v0.3
+        env:
+          VSCODE_COMMIT: ${{ steps.vscode-commit.outputs.vscode_commit }}
         with:
           imageName: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           imageTag: ${{ steps.tags.outputs.tags }}
           cacheFrom: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           push: always
-          env: |
-            VSCODE_COMMIT=${{ steps.vscode-commit.outputs.vscode_commit }}
           # Test the container with a simple validation
           runCmd: |
             echo "=== Testing dev container ==="

--- a/.github/workflows/build-devcontainer.yml
+++ b/.github/workflows/build-devcontainer.yml
@@ -31,23 +31,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Determine VSCODE_COMMIT
+      - name: Override VSCODE_COMMIT if provided
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          # Update devcontainer.json with the provided VSCODE_COMMIT
+          sed -i 's/"VSCODE_COMMIT": "${VSCODE_COMMIT:-[^}]*}"/"VSCODE_COMMIT": "${{ github.event.inputs.vscode_commit }}"/' .devcontainer/devcontainer.json
+          echo "Updated devcontainer.json with VSCODE_COMMIT: ${{ github.event.inputs.vscode_commit }}"
+
+      - name: Read VSCODE_COMMIT from devcontainer.json
         id: vscode-commit
         run: |
-          # For manual dispatch, use the required input
-          # For PR builds, read from devcontainer.json
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VSCODE_COMMIT="${{ github.event.inputs.vscode_commit }}"
-            echo "Using VSCODE_COMMIT from workflow input: $VSCODE_COMMIT"
-          else
-            VSCODE_COMMIT=$(grep 'VSCODE_COMMIT' .devcontainer/devcontainer.json | tr -d '"' | cut -d " " -f 2)
-            echo "Using VSCODE_COMMIT from devcontainer.json: $VSCODE_COMMIT"
-          fi
-          
+          # Always read from devcontainer.json (which may have been updated above)
+          VSCODE_COMMIT=$(grep 'VSCODE_COMMIT' .devcontainer/devcontainer.json | tr -d '"' | cut -d " " -f 2)
           VSCODE_SHORT=${VSCODE_COMMIT:0:7}
           echo "vscode_commit=$VSCODE_COMMIT" >> $GITHUB_OUTPUT
           echo "vscode_short=$VSCODE_SHORT" >> $GITHUB_OUTPUT
-          echo "Full VSCODE_COMMIT: $VSCODE_COMMIT"
+          echo "Using VSCODE_COMMIT: $VSCODE_COMMIT"
           echo "Short VSCODE_COMMIT: $VSCODE_SHORT"
 
       - name: Set up Docker Buildx

--- a/DEVCONTAINER.md
+++ b/DEVCONTAINER.md
@@ -13,11 +13,14 @@ The dev container is automatically built and published with multiple tags:
   - `main` - Latest build from main branch  
   - `main-<commit-sha>` - Specific commit builds from main branch
   - `pr-<number>` - Pull request builds for testing
+  - `vscode-<vscode-commit-sha>` - Builds with specific VS Code Server versions
+  - `vscode-<vscode-commit-sha>-<commit-sha>` - Combination of VS Code Server and container commit
 
 ### Choosing the Right Tag
 
 - **For production/stable use**: `ghcr.io/smartdatafoundry/devcontainer:latest`
-- **For reproducible builds**: `ghcr.io/smartdatafoundry/devcontainer:main-abc1234` 
+- **For reproducible builds**: `ghcr.io/smartdatafoundry/devcontainer:vscode-<vscode-commit-sha>-<commit-sha>` 
+- **For specific VS Code Server versions**: `ghcr.io/smartdatafoundry/devcontainer:vscode-<vscode-commit-sha>`
 - **For testing PR changes**: `ghcr.io/smartdatafoundry/devcontainer:pr-123`
 
 ## 🚀 Quick Start
@@ -76,16 +79,24 @@ This dev container includes:
   - Jupyter support
   - Markdown All in One
   - Rainbow CSV
+  - etc.
 
 ## 🔄 Automated Builds
 
-The container is automatically built and published using GitHub Actions:
+The container is built using GitHub Actions with controlled publishing:
 
 ### Build Workflow (`build-devcontainer.yml`)
-- **Triggers**: Push to main branch, PRs, manual dispatch
-- **Features**: Single platform (linux/amd64), intelligent caching, comprehensive validation tests
-- **Publishing**: Multi-tag publishing with `latest`, `main`, `main-<sha>`, and `pr-<number>` tags
+- **PR Triggers**: Pull requests automatically build test images (`pr-<number>` tags) using default VS Code Server commit
+- **Manual Dispatch**: Production builds require manual trigger with VS Code Server commit hash
+  - **Required Input**: VS Code Server commit hash for reproducible builds
+  - **Publishing**: Multi-tag publishing with `latest`, `main`, `vscode-<vscode-commit>`, and SHA-based tags
+- **Features**: Single platform (linux/amd64), intelligent caching, comprehensive validation tests, security scanning
 - **Testing**: Validates Python, Git, Zsh, and Quarto installations
+
+### VS Code Server Version Control
+- Default VS Code Server commit is defined in the `VSCODE_COMMIT` environment variable in `.github/workflows/build-devcontainer.yml`
+- Can be overridden via manual workflow dispatch input for custom builds
+- The VS Code Server commit hash is embedded in container tags for version tracking
 
 ## 📁 Repository Structure
 
@@ -143,6 +154,8 @@ The build system creates multiple tags from a single build:
 - `main`: Latest commit from main branch
 - `main-<sha>`: Specific commit SHA for reproducible builds
 - `pr-<number>`: Pull request builds for testing changes
+- `vscode-<vscode-commit-sha>`: Builds with specific VS Code Server versions
+- `vscode-<vscode-commit-sha>-<container-sha>`: Complete version specification
 
 ## 🧪 Testing
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ This dev container is automatically built and published to GitHub Container Regi
   - `main` - Latest build from main branch  
   - `main-<commit-sha>` - Specific commit builds from main branch
   - `pr-<number>` - Pull request builds for testing
-  - `vscode-<vscode-commit-sha>` - Builds with specific VS Code versions
-  - `vscode-<vscode-commit-sha>-<commit-sha>` - Combination of VS Code and git commit
+  - `vscode-<vscode-commit-sha>` - Builds with specific VS Code Server versions
+  - `vscode-<vscode-commit-sha>-<commit-sha>` - Combination of VS Code Server and container commit
 
-**Recommended**: Use `latest` for stable deployments or `main-<commit-sha>` for reproducible builds.
+**Recommended**: Use `latest` for stable deployments or `vscode-<vscode-commit-sha>` for reproducible builds with specific VS Code Server versions.
 
 ## 🚀 Quick Start
 
@@ -59,7 +59,7 @@ This includes:
 
 - [SDF TRE Setup Guide](SDF_TRE_SETUP.md) - Complete setup guide for SDF Trusted Research Environment
 - [Dev Container Details](DEVCONTAINER.md) - Complete documentation about the container
-- [Usage Examples](examples/USAGE.md) - Examples of how to use the published container
+- [Build & Publish Guide](docs/BUILD_PUBLISH_CONTAINER.md) - Guide for building and publishing containers
 - [Dev Container Spec](https://containers.dev) - Learn more about dev containers
 
 ## 🛠️ What's Included
@@ -101,24 +101,37 @@ The container comes with VS Code Server pre-installed for immediate development.
 
 ## Adding New Extensions
 To add new VS Code extensions to the container, follow these steps:
-1. Open the `.devcontainer/vscode-init/vscode-extensions.txt` file.
+1. Open the appropriate file in `.devcontainer/vscode-init/`:
+   - `extensions-to-install.txt` for extensions to install directly
+   - `extensions-to-download.txt` for extensions that need to be downloaded first
 2. Add the identifier of the desired extension in the format `publisher.extensionName` on a new line.
-3. Save the changes to the `vscode-extensions.txt` file.
+3. Save the changes to the extension file.
 4. Commit and push the changes to your repository to trigger the build workflow with the updated extensions
 
 ## 🔄 Automated Builds
 
 The container is built automatically with smart tagging:
 
-- **Main Branch Pushes**: Creates `latest`, `main`, and `main-<commit-sha>` tags
-- **Pull Requests**: Creates `pr-<number>` tags for testing
-- **VS Code Commits**: Creates `vscode-<vscode-commit-sha>` and `vscode-<vscode-commit-sha>-<commit-sha>` tags
-- **Manual Dispatch**: Available for on-demand builds
+- **Pull Requests**: Creates `pr-<number>` tags for testing (uses default VS Code Server commit)
+- **Manual Dispatch**: Creates production tags with custom VS Code Server commit hash
+  - Required input: VS Code Server commit hash
+  - Creates `latest`, `main`, `vscode-<vscode-commit-sha>`, and commit-based tags
 - **Platform**: linux/amd64 optimized for development speed
+
+### Manual Build Process
+
+To create a production build with a specific VS Code Server version:
+
+1. Go to [Actions → Build and Publish Dev Container](../../actions/workflows/build-devcontainer.yml)
+2. Click "Run workflow"
+3. Enter the desired VS Code Server commit hash (required)
+4. Click "Run workflow"
+
+This ensures all published builds use the correct VS Code Server version and prevents automatic builds with mismatched versions.
 
 ### Tag Strategy
 - Use `latest` for the most recent stable release
 - Use `main-<commit-sha>` when you need reproducible builds
 - Use `pr-<number>` tags to test specific pull request changes
-- Use `vscode-<commit-sha>` tags to match specific VS Code versions
-- Use `vscode-<commit-sha>-<container-commit-sha>` tags for a combination of VS Code and git commits
+- Use `vscode-<vscode-commit-sha>` tags to match specific VS Code Server versions
+- Use `vscode-<vscode-commit-sha>-<container-commit-sha>` tags for complete reproducibility (specific VS Code Server + container version)

--- a/SDF_TRE_SETUP.md
+++ b/SDF_TRE_SETUP.md
@@ -147,20 +147,20 @@ This approach leverages container technology directly while maintaining the abil
 The container comes with VS Code Server pre-installed and to control the version to match your TRE environment, you can specify the commit hash of the VS Code Server version to use as follows:
 
 1. Check your TRE VS Code version via _Help > About_
-2. Specify the VS Code commit in this repository's `devcontainer.json` file which is used for building the container, not to be confused with TRE workspace settings:
+2. The VS Code commit is defined in this repository's `.github/workflows/build-devcontainer.yml` with support for environment variable substitution, replace `default_commit_hash` with the commit hash you want to use:
 
    ```json
    {
      "build": {
        "dockerfile": "Dockerfile", 
        "args": {
-         "VSCODE_COMMIT": "your_commit_hash_here"
+         "VSCODE_COMMIT": "${localEnv:VSCODE_COMMIT:default_commit_hash}"
        }
      }
    }
    ```
 
-3. This is typically only needed for custom container builds, not when using the published container
+   This allows you to override the VS Code Server version using the `VSCODE_COMMIT` environment variable when building locally.
 
 ## Troubleshooting
 

--- a/docs/BUILD_PUBLISH_CONTAINER.md
+++ b/docs/BUILD_PUBLISH_CONTAINER.md
@@ -91,7 +91,8 @@ For further help, consult the GitHub Actions documentation or reach out to your 
 | Use Case | Recommended Tag | Example | Benefits |
 |----------|----------------|---------|----------|
 | **Development** | `latest` | `ghcr.io/smartdatafoundry/devcontainer:latest` | Always up-to-date, stable |
-| **Production/CI** | `main-<sha>` | `ghcr.io/smartdatafoundry/devcontainer:main-abc1234` | Reproducible, immutable |
+| **Production/CI** | `vscode-<vscode-sha>-<sha>` | `ghcr.io/smartdatafoundry/devcontainer:vscode-f220831-abc1234` | Reproducible, immutable, specific VS Code Server |
+| **VS Code Version Match** | `vscode-<vscode-sha>` | `ghcr.io/smartdatafoundry/devcontainer:vscode-f220831` | Match specific VS Code Server version |
 | **Testing PRs** | `pr-<number>` | `ghcr.io/smartdatafoundry/devcontainer:pr-42` | Test specific changes |
 | **Latest Main** | `main` | `ghcr.io/smartdatafoundry/devcontainer:main` | Latest main branch |
 


### PR DESCRIPTION
This pull request introduces improvements to how the VS Code Server version is managed and tagged in the dev container build and publish workflow. It enables precise control over the VS Code Server version used in container builds, improves reproducibility, and updates documentation to reflect these changes. The workflow now supports manual input of the VS Code Server commit hash for production builds, and all relevant documentation and tagging strategies have been updated.

**Build and Workflow Enhancements**

* The GitHub Actions workflow (`build-devcontainer.yml`) now requires the VS Code Server commit hash as an input for manual dispatch, enabling explicit control over the VS Code Server version used in production builds. The environment variable `VSCODE_COMMIT` is set from workflow input and used for image tagging. [[1]](diffhunk://#diff-9e7aa162468893bcd63bec27aaaf166c035adc221d13d8c5796f6b1ccc3d8984L4-R21) [[2]](diffhunk://#diff-9e7aa162468893bcd63bec27aaaf166c035adc221d13d8c5796f6b1ccc3d8984L35-L43) [[3]](diffhunk://#diff-9e7aa162468893bcd63bec27aaaf166c035adc221d13d8c5796f6b1ccc3d8984R81-R82)
* The `.devcontainer/devcontainer.json` now supports environment variable substitution for `VSCODE_COMMIT`, allowing local overrides and consistent version control between local and CI builds.

**Tagging Strategy and Version Control**

* Container image tags now include the VS Code Server commit hash (e.g., `vscode-<vscode-commit-sha>` and `vscode-<vscode-commit-sha>-<commit-sha>`), ensuring reproducibility and traceability of builds. Documentation in `DEVCONTAINER.md`, `README.md`, and `docs/BUILD_PUBLISH_CONTAINER.md` is updated to reflect this strategy. [[1]](diffhunk://#diff-caf6e71b33baaca4eaa241de21584d72472b8573a847d3c1407d6ee7df8df5f4R16-R23) [[2]](diffhunk://#diff-caf6e71b33baaca4eaa241de21584d72472b8573a847d3c1407d6ee7df8df5f4R157-R158) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R25) [[4]](diffhunk://#diff-8a92322fbc90eb71c15f3919ee54a6985079fcc460cebf85e7de64f689f1f862L94-R95)

**Documentation Improvements**

* The build and publish process is clarified in `DEVCONTAINER.md`, `README.md`, and `SDF_TRE_SETUP.md`, including instructions for manual builds, extension management, and VS Code Server version control. [[1]](diffhunk://#diff-caf6e71b33baaca4eaa241de21584d72472b8573a847d3c1407d6ee7df8df5f4R82-R100) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L104-R137) [[3]](diffhunk://#diff-5a19f994d9695678dc88c45d0048f86377a73a969c0136b2e043608fd6bdb154L150-R163)

**File and Guide Organization**

* The main README now links to a dedicated build and publish guide (`docs/BUILD_PUBLISH_CONTAINER.md`) instead of usage examples, making it easier to find information about building and publishing containers.

Let me know if you want more details about how to use the new workflow inputs or tagging conventions!